### PR TITLE
create autoblock image link and style circle links

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -11,13 +11,22 @@
     font-size: var(--heading-font-size-l);
 }
 
-.services-3 .cards > ul {
-    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-}
-
 .cards > ul > li {
     border: 1px solid var(--highlight-background-color);
     background-color: var(--background-color)
+}
+
+.resources > ul {
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+}
+
+.resources .cards-card-image, .resources .cards-card-image a:link, .resources .cards-card-image a:visited {
+    background-color: #006554;
+    color: white;
+}
+
+.services-3 .cards > ul {
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
 }
 
 .cards .cards-card-body {
@@ -46,13 +55,4 @@
 
 .circles figcaption {
     padding-top: 10px;
-}
-
-.resources .cards-card-image, .resources .cards-card-image a:link, .resources .cards-card-image a:visited {
-    background-color: #006554;
-    color: white;
-}
-
-.resources > ul {
-    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -48,7 +48,7 @@
     padding-top: 10px;
 }
 
-.resources .cards-card-image, .resources .cards-card-image a:link {
+.resources .cards-card-image, .resources .cards-card-image a:link, .resources .cards-card-image a:visited {
     background-color: #006554;
     color: white;
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -3,7 +3,7 @@
     margin: 0;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     grid-gap: 30px;
 }
 
@@ -25,31 +25,34 @@
 }
 
 .cards .cards-card-image {
-    line-height: 0;
+    line-height: 1.3;
 }
 
 .cards .cards-card-body > *:first-child {
     margin-top: 0;
 }
 
-.cards > ul > li img {
-    width: 100%;
-    object-fit: cover;
+.circles .cards-card-image img {
+   transition: transform .2s ease-in-out;
 }
 
-.circles .cards-card-body a:link, .circles .button-container a:link {
-    border: none;
-    text-transform: unset;
-    padding: unset;
-    font-weight: normal;
-    letter-spacing: unset;
+.circles .cards-card-image:hover img {
+    transform: scale(1.1) rotate(10deg);
 }
 
 .circles .cards-wrapper {
     padding-top: 50px;
 }
 
-.circles h3 {
-    font-weight: normal;
-    color: #006554;
+.circles figcaption {
+    padding-top: 10px;
+}
+
+.resources .cards-card-image, .resources .cards-card-image a:link {
+    background-color: #006554;
+    color: white;
+}
+
+.resources > ul {
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
 }

--- a/blocks/parallax/parallax.css
+++ b/blocks/parallax/parallax.css
@@ -14,7 +14,7 @@ main .parallax-background {
 }
 
 main .parallax-background > div {
-    background-color: var(--text-color);
+    background-color: rgba(0,0,0,0.6);
     color: var(--background-color);
     padding: 0 20px;
     text-align: center;

--- a/blocks/parallax/parallax.css
+++ b/blocks/parallax/parallax.css
@@ -14,7 +14,7 @@ main .parallax-background {
 }
 
 main .parallax-background > div {
-    background-color: rgba(0,0,0,0.6);
+    background-color: rgb(0 0 0 / 60%);
     color: var(--background-color);
     padding: 0 20px;
     text-align: center;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -30,24 +30,24 @@ function buildHeroBlock(main) {
 // if an image has a soft return with link under it
 function decorateImageLink(block) {
   [...block.querySelectorAll('picture + br + a')]
-  .filter((a) => a.href === a.textContent)
-      .forEach((a) => {
-        const picture = a.previousElementSibling.previousElementSibling;
-        picture.remove();
-        a.previousElementSibling.remove();
-        const imageLink = a.parentElement.nextElementSibling;
-        if (imageLink.childElementCount === 1 && imageLink.firstElementChild.nodeName === 'A') {
-          const figure = document.createElement('figure');
-          figure.append(picture);
-          const caption = document.createElement('figcaption');
-          caption.innerHTML = imageLink.firstElementChild.innerHTML;
-          figure.append(caption);
-          a.innerHTML = figure.outerHTML;
-          imageLink.remove();
-        } else {
-          a.innerHTML = picture.outerHTML;
-        }
-      });
+    .filter((a) => a.href === a.textContent)
+    .forEach((a) => {
+      const picture = a.previousElementSibling.previousElementSibling;
+      picture.remove();
+      a.previousElementSibling.remove();
+      const imageLink = a.parentElement.nextElementSibling;
+      if (imageLink.childElementCount === 1 && imageLink.firstElementChild.nodeName === 'A') {
+        const figure = document.createElement('figure');
+        figure.append(picture);
+        const caption = document.createElement('figcaption');
+        caption.innerHTML = imageLink.firstElementChild.innerHTML;
+        figure.append(caption);
+        a.innerHTML = figure.outerHTML;
+        imageLink.remove();
+      } else {
+        a.innerHTML = picture.outerHTML;
+      }
+    });
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -27,6 +27,29 @@ function buildHeroBlock(main) {
   }
 }
 
+// if an image has a soft return with link under it
+function decorateImageLink(block) {
+  [...block.querySelectorAll('picture + br + a')]
+  .filter((a) => a.href === a.textContent)
+      .forEach((a) => {
+        const picture = a.previousElementSibling.previousElementSibling;
+        picture.remove();
+        a.previousElementSibling.remove();
+        const imageLink = a.parentElement.nextElementSibling;
+        if (imageLink.childElementCount === 1 && imageLink.firstElementChild.nodeName === 'A') {
+          const figure = document.createElement('figure');
+          figure.append(picture);
+          const caption = document.createElement('figcaption');
+          caption.innerHTML = imageLink.firstElementChild.innerHTML;
+          figure.append(caption);
+          a.innerHTML = figure.outerHTML;
+          imageLink.remove();
+        } else {
+          a.innerHTML = picture.outerHTML;
+        }
+      });
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -34,6 +57,7 @@ function buildHeroBlock(main) {
 function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
+    decorateImageLink(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);


### PR DESCRIPTION
I separated out the 4 shopping link circles (gloves + bats) from the last 3 Resource circle links in the Word doc, and made a temporary style for the resources. These are different categories and I think the visual separation will help a user distinguish the difference better. I will come back and style these in another ticket.

Fix #14 

Test URLs:
- Before: https://main--dsg--hlxsites.hlx.page/
- After: https://issue14-imglinks--dsg--hlxsites.hlx.page/
